### PR TITLE
Remove `resources` from .gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -6,5 +6,4 @@
 /.travis.yml             export-ignore
 /phpunit.xml.dist        export-ignore
 /package-banner@2x.png   export-ignore
-/resources/              export-ignore
 /tests/                  export-ignore


### PR DESCRIPTION
With `/resources/` not being downloaded when requiring through Composer, the package won't work because there are no theme files included.

This maybe closes #9.